### PR TITLE
Conditionally disallow thumbnails from being locally captured

### DIFF
--- a/FckSessionCapture/FckSessionCapture.cs
+++ b/FckSessionCapture/FckSessionCapture.cs
@@ -72,8 +72,6 @@ public class FckSessionCapture : ResoniteMod {
 	[HarmonyPatch(typeof(SessionThumbnailData), "ShouldCapture")]
 	class SessionThumbnailData_ShouldCapture_Patch {
 		static bool Prefix(SessionThumbnailData __instance) {
-			Msg("FckSessionCapture: ShouldCapture Prefix entered.");
-
 			if (Config == null) {
 				Error("FckSessionCapture: Config is null! Allowing capture.");
 				return true;
@@ -90,7 +88,6 @@ public class FckSessionCapture : ResoniteMod {
 			bool locallyCapture = Config.GetValue(alwaysCapture);
 
 			if (!modEnabled) {
-				Msg("FckSessionCapture: Mod is disabled, allowing capture.");
 				return true;
 			}
 
@@ -105,52 +102,41 @@ public class FckSessionCapture : ResoniteMod {
 			}
 
 			var accessLevel = world.AccessLevel;
-			Msg($"FckSessionCapture: World '{world.Name}' (AccessLevel={accessLevel}, Focused={world.Focus == World.WorldFocus.Focused})");
 
 			// Block or allow based on session type and config
 			switch (accessLevel) {
 				case SessionAccessLevel.Private:
 					if (!allowLocal && !allowPrivate) {
-						Warn("Blocked session thumbnail capture in private session.");
 						return false;
 					}
 					break;
 				case SessionAccessLevel.Contacts:
 					if (!allowLocal && !allowContacts) {
-						Warn("Blocked session thumbnail capture in contacts-only session.");
 						return false;
 					}
 					break;
 				case SessionAccessLevel.ContactsPlus:
 					if (!allowLocal && !allowContactsPlus) {
-						Warn("Blocked session thumbnail capture in contacts+ session.");
 						return false;
 					}
 					break;
 				case SessionAccessLevel.RegisteredUsers:
 					if (!allowLocal && !allowRegisteredUsers) {
-						Warn("Blocked session thumbnail capture in registered users session.");
 						return false;
 					}
 					break;
 				case SessionAccessLevel.LAN:
 					if (!allowLocal && !allowLAN) {
-						Warn("Blocked session thumbnail capture in LAN session.");
 						return false;
 					}
 					break;
 				case SessionAccessLevel.Anyone:
 					if (!allowLocal && !allowPublic) {
-						Warn("Blocked session thumbnail capture in public (Anyone) session.");
 						return false;
 					}
 					break;
-				default:
-					Msg("FckSessionCapture: Unknown session type, allowing capture.");
-					break;
 			}
 
-			Msg("FckSessionCapture: ShouldCapture Prefix exiting, allowing capture.");
 			return true;
 		}
 	}

--- a/FckSessionCapture/FckSessionCapture.cs
+++ b/FckSessionCapture/FckSessionCapture.cs
@@ -49,6 +49,14 @@ public class FckSessionCapture : ResoniteMod {
 			() => true
 		);
 
+	[AutoRegisterConfigKey]
+	private static readonly ModConfigurationKey<bool> alwaysCapture =
+		new ModConfigurationKey<bool>(
+			"always_locally_capture",
+			"Always locally capture thumbnails, even when not uploading or sharing with the local session.",
+			() => false
+		);
+
 	private static ModConfiguration Config;
 
 	public override void OnEngineInit() {
@@ -79,9 +87,14 @@ public class FckSessionCapture : ResoniteMod {
 			bool allowLAN = Config.GetValue(captureInLAN);
 			bool allowPublic = Config.GetValue(captureInPublic);
 			bool allowLocal = Config.GetValue(captureLocal);
+			bool locallyCapture = Config.GetValue(alwaysCapture);
 
 			if (!modEnabled) {
 				Msg("FckSessionCapture: Mod is disabled, allowing capture.");
+				return true;
+			}
+
+			if (locallyCapture) {
 				return true;
 			}
 

--- a/FckSessionCapture/FckSessionCapture.csproj
+++ b/FckSessionCapture/FckSessionCapture.csproj
@@ -29,24 +29,31 @@
 	<ItemGroup>
 		<Reference Include="Elements.Core">
 		  <HintPath>$(ResonitePath)Elements.Core.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Elements.Data">
 		  <HintPath>$(ResonitePath)Elements.Data.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="FrooxEngine">
 		  <HintPath>$(ResonitePath)FrooxEngine.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="FrooxEngine.Store">
 		  <HintPath>$(ResonitePath)FrooxEngine.Store.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Newtonsoft.Json">
 		  <HintPath>$(ResonitePath)Newtonsoft.Json.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="ResoniteHotReloadLib">
 		  <HintPath>$(ResonitePath)rml_libs\ResoniteHotReloadLib.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="ResoniteHotReloadLibCore">
 		  <HintPath>$(ResonitePath)rml_libs\ResoniteHotReloadLibCore.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="ResoniteModLoader">
 			<HintPath>$(ResonitePath)Libraries\ResoniteModLoader.dll</HintPath>
@@ -58,9 +65,11 @@
 		</Reference>
 		<Reference Include="SkyFrost.Base">
 		  <HintPath>$(ResonitePath)SkyFrost.Base.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="SkyFrost.Base.Models">
 		  <HintPath>$(ResonitePath)SkyFrost.Base.Models.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 	</ItemGroup>
 

--- a/FckSessionCapture/FckSessionCapture.csproj
+++ b/FckSessionCapture/FckSessionCapture.csproj
@@ -28,25 +28,25 @@
 
 	<ItemGroup>
 		<Reference Include="Elements.Core">
-		  <HintPath>E:\SteamLibrary\steamapps\common\Resonite\Elements.Core.dll</HintPath>
+		  <HintPath>$(ResonitePath)Elements.Core.dll</HintPath>
 		</Reference>
 		<Reference Include="Elements.Data">
-		  <HintPath>E:\SteamLibrary\steamapps\common\Resonite\Elements.Data.dll</HintPath>
+		  <HintPath>$(ResonitePath)Elements.Data.dll</HintPath>
 		</Reference>
 		<Reference Include="FrooxEngine">
-		  <HintPath>E:\SteamLibrary\steamapps\common\Resonite\FrooxEngine.dll</HintPath>
+		  <HintPath>$(ResonitePath)FrooxEngine.dll</HintPath>
 		</Reference>
 		<Reference Include="FrooxEngine.Store">
-		  <HintPath>E:\SteamLibrary\steamapps\common\Resonite\FrooxEngine.Store.dll</HintPath>
+		  <HintPath>$(ResonitePath)FrooxEngine.Store.dll</HintPath>
 		</Reference>
 		<Reference Include="Newtonsoft.Json">
-		  <HintPath>E:\SteamLibrary\steamapps\common\Resonite\Newtonsoft.Json.dll</HintPath>
+		  <HintPath>$(ResonitePath)Newtonsoft.Json.dll</HintPath>
 		</Reference>
 		<Reference Include="ResoniteHotReloadLib">
-		  <HintPath>E:\SteamLibrary\steamapps\common\Resonite\rml_libs\ResoniteHotReloadLib.dll</HintPath>
+		  <HintPath>$(ResonitePath)rml_libs\ResoniteHotReloadLib.dll</HintPath>
 		</Reference>
 		<Reference Include="ResoniteHotReloadLibCore">
-		  <HintPath>E:\SteamLibrary\steamapps\common\Resonite\rml_libs\ResoniteHotReloadLibCore.dll</HintPath>
+		  <HintPath>$(ResonitePath)rml_libs\ResoniteHotReloadLibCore.dll</HintPath>
 		</Reference>
 		<Reference Include="ResoniteModLoader">
 			<HintPath>$(ResonitePath)Libraries\ResoniteModLoader.dll</HintPath>
@@ -57,10 +57,10 @@
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="SkyFrost.Base">
-		  <HintPath>E:\SteamLibrary\steamapps\common\Resonite\SkyFrost.Base.dll</HintPath>
+		  <HintPath>$(ResonitePath)SkyFrost.Base.dll</HintPath>
 		</Reference>
 		<Reference Include="SkyFrost.Base.Models">
-		  <HintPath>E:\SteamLibrary\steamapps\common\Resonite\SkyFrost.Base.Models.dll</HintPath>
+		  <HintPath>$(ResonitePath)SkyFrost.Base.Models.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 


### PR DESCRIPTION
Currently, this mod only prevents thumbnails from being uploaded, but they are still captured and written to the assets folder in the data folder. This PR aims to change that to reduce local database bloat, reduce disk writes (primarily for SSDs), and reduce accumulated disk usage.

This was done by adapting the existing StartUpload patch to a separate patch that prefixes the ShouldCapture method. If uploading and local capture are both disabled, ShouldCapture is skipped entirely. There is also a new config option to always capture thumbnails anyway even when they're never uploaded or shared, incase a user wants to still see their thumbnails locally.

Additionally, while I did try to keep the format similar to the rest of the mod, ShouldCapture is called very often, resulting in very noisy logs with the current logging structure. If you would prefer the logs to be there anyway, the change can be reverted but it may be worth considering limiting logs in some way, such as with an internal config key or debug builds only.

Lastly, the csproj file was changed to use the ResonitePath variable to fix building on Linux and the Private tag was added and set to false to prevent unneccesary copying of referenced assemblies.