### PR TITLE
Updated the `SessionCaptureBlocker` mod to version 1.1.0.

### DIFF
--- a/SessionCaptureBlocker/SessionCaptureBlocker.cs
+++ b/SessionCaptureBlocker/SessionCaptureBlocker.cs
@@ -2,12 +2,14 @@ using HarmonyLib;
 using ResoniteModLoader;
 using FrooxEngine;
 using SkyFrost.Base;
+using Elements.Assets;
+using System.Threading.Tasks;
 
 namespace SessionCaptureBlocker;
 
 public class SessionCaptureBlocker : ResoniteMod
 {
-    internal const string VERSION_CONSTANT = "1.0.3";
+    internal const string VERSION_CONSTANT = "1.1.0";
     public override string Name => "SessionCaptureBlocker";
     public override string Author => "NalaTheThird";
     public override string Version => VERSION_CONSTANT;
@@ -22,6 +24,10 @@ public class SessionCaptureBlocker : ResoniteMod
         new ModConfigurationKey<bool>("capture_in_private_session", "Allow capture in private sessions", () => false);
 
     [AutoRegisterConfigKey]
+    private static readonly ModConfigurationKey<bool> captureInLAN =
+    new ModConfigurationKey<bool>("capture_in_lan_session", "Allow capture in LAN (local network) sessions", () => false);
+
+    [AutoRegisterConfigKey]
     private static readonly ModConfigurationKey<bool> captureInContactsOnly =
         new ModConfigurationKey<bool>("capture_in_contactsonly_session", "Allow capture in contacts-only sessions", () => false);
 
@@ -32,10 +38,6 @@ public class SessionCaptureBlocker : ResoniteMod
     [AutoRegisterConfigKey]
     private static readonly ModConfigurationKey<bool> captureInRegisteredUsers =
         new ModConfigurationKey<bool>("capture_in_registeredusers_session", "Allow capture in registered users sessions", () => false);
-
-    [AutoRegisterConfigKey]
-    private static readonly ModConfigurationKey<bool> captureInLAN =
-        new ModConfigurationKey<bool>("capture_in_lan_session", "Allow capture in LAN (local network) sessions", () => false);
 
     [AutoRegisterConfigKey]
     private static readonly ModConfigurationKey<bool> captureInPublic =
@@ -66,7 +68,6 @@ public class SessionCaptureBlocker : ResoniteMod
 
         var harmony = new Harmony("com.nalathethird.SessionCaptureBlocker");
         harmony.PatchAll();
-        Msg("Harmony patch applied - Sessions are now Private!");
     }
 
     [HarmonyPatch(typeof(SessionThumbnailData), "ShouldCapture")]
@@ -289,6 +290,143 @@ public class SessionCaptureBlocker : ResoniteMod
             }
 
             Msg("StartUpload Prefix exiting, allowing upload.");
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(CaptureThumbnailSource), "GetThumbnail")]
+    class CaptureThumbnailSource_GetThumbnail_Patch
+    {
+        static bool Prefix(CaptureThumbnailSource __instance, ref Task<Bitmap2D> __result)
+        {
+            if (Config == null)
+            {
+                Error("Config is null! Allowing thumbnail capture.");
+                return true;
+            }
+
+            bool modEnabled = Config.GetValue(enabled);
+            bool locallyCapture = Config.GetValue(alwaysCapture);
+
+            if (!modEnabled)
+            {
+                return true;
+            }
+
+            if (locallyCapture)
+            {
+                return true;
+            }
+
+            var world = __instance.World;
+            if (world == null)
+            {
+                Error("World is null in CaptureThumbnailSource! Allowing capture.");
+                return true;
+            }
+
+            bool allowLocal = Config.GetValue(captureLocal);
+            var accessLevel = world.AccessLevel;
+
+            bool shouldBlock = false;
+
+            switch (accessLevel)
+            {
+                case SessionAccessLevel.Private:
+                    shouldBlock = !Config.GetValue(captureInPrivate) && !allowLocal;
+                    break;
+                case SessionAccessLevel.Contacts:
+                    shouldBlock = !Config.GetValue(captureInContactsOnly) && !allowLocal;
+                    break;
+                case SessionAccessLevel.ContactsPlus:
+                    shouldBlock = !Config.GetValue(captureInContactsPlus) && !allowLocal;
+                    break;
+                case SessionAccessLevel.RegisteredUsers:
+                    shouldBlock = !Config.GetValue(captureInRegisteredUsers) && !allowLocal;
+                    break;
+                case SessionAccessLevel.LAN:
+                    shouldBlock = !Config.GetValue(captureInLAN) && !allowLocal;
+                    break;
+                case SessionAccessLevel.Anyone:
+                    shouldBlock = !Config.GetValue(captureInPublic) && !allowLocal;
+                    break;
+            }
+
+            if (shouldBlock)
+            {
+                Msg($"Blocked GetThumbnail for {accessLevel} session - preventing rendering entirely.");
+                __result = Task.FromResult<Bitmap2D>(null);
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(CaptureThumbnailSource), "CaptureThumbnail")]
+    class CaptureThumbnailSource_CaptureThumbnail_Patch
+    {
+        static bool Prefix(World world, ref Task<Bitmap2D> __result)
+        {
+            if (Config == null)
+            {
+                Error("Config is null! Allowing thumbnail capture.");
+                return true;
+            }
+
+            bool modEnabled = Config.GetValue(enabled);
+            bool locallyCapture = Config.GetValue(alwaysCapture);
+
+            if (!modEnabled)
+            {
+                return true;
+            }
+
+            if (locallyCapture)
+            {
+                return true;
+            }
+
+            if (world == null)
+            {
+                Error("World is null in CaptureThumbnail! Allowing capture.");
+                return true;
+            }
+
+            bool allowLocal = Config.GetValue(captureLocal);
+            var accessLevel = world.AccessLevel;
+
+            bool shouldBlock = false;
+
+            switch (accessLevel)
+            {
+                case SessionAccessLevel.Private:
+                    shouldBlock = !Config.GetValue(captureInPrivate) && !allowLocal;
+                    break;
+                case SessionAccessLevel.Contacts:
+                    shouldBlock = !Config.GetValue(captureInContactsOnly) && !allowLocal;
+                    break;
+                case SessionAccessLevel.ContactsPlus:
+                    shouldBlock = !Config.GetValue(captureInContactsPlus) && !allowLocal;
+                    break;
+                case SessionAccessLevel.RegisteredUsers:
+                    shouldBlock = !Config.GetValue(captureInRegisteredUsers) && !allowLocal;
+                    break;
+                case SessionAccessLevel.LAN:
+                    shouldBlock = !Config.GetValue(captureInLAN) && !allowLocal;
+                    break;
+                case SessionAccessLevel.Anyone:
+                    shouldBlock = !Config.GetValue(captureInPublic) && !allowLocal;
+                    break;
+            }
+
+            if (shouldBlock)
+            {
+                Msg($"Blocked CaptureThumbnail for {accessLevel} session - no GPU/CPU rendering will occur.");
+                __result = Task.FromResult<Bitmap2D>(null);
+                return false;
+            }
+
             return true;
         }
     }

--- a/SessionCaptureBlocker/SessionCaptureBlocker.csproj
+++ b/SessionCaptureBlocker/SessionCaptureBlocker.csproj
@@ -3,9 +3,9 @@
 		<RootNamespace>SessionCaptureBlocker</RootNamespace>
 		<AssemblyName>SessionCaptureBlocker</AssemblyName>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<FileAlignment>512</FileAlignment>
-		<LangVersion>12.0</LangVersion>
+		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<Deterministic>true</Deterministic>
 		<!-- Change CopyToMods to true if you'd like builds to be moved into the Mods folder automatically-->
@@ -17,10 +17,11 @@
     <!-- If you don't want to provide a ResonitePath in dotnet build, you can specify one here -->
     <ResonitePath>$(MSBuildThisFileDirectory)Resonite/</ResonitePath>
     <ResonitePath Condition="Exists('E:\SteamLibrary\steamapps\common\Resonite\')">E:\SteamLibrary\steamapps\common\Resonite\</ResonitePath>
+    <ResonitePath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
     <ResonitePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</ResonitePath>
   </PropertyGroup>
 
-	<ItemGroup>
+  <ItemGroup>
 		<Reference Include="FrooxEngine">
 		  <HintPath>$(ResonitePath)FrooxEngine.dll</HintPath>
 		</Reference>
@@ -32,6 +33,9 @@
 			<HintPath>$(ResonitePath)rml_libs\0Harmony.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+    <Reference Include="Elements.Assets">
+      <HintPath>$(ResonitePath)Elements.Assets.dll</HintPath>
+    </Reference>
 		<Reference Include="SkyFrost.Base">
 		  <HintPath>$(ResonitePath)SkyFrost.Base.dll</HintPath>
 			<Private>False</Private>
@@ -39,10 +43,6 @@
 		<Reference Include="SkyFrost.Base.Models">
 		  <HintPath>$(ResonitePath)SkyFrost.Base.Models.dll</HintPath>
 		</Reference>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="Resonite\rml_mods\" />
 	</ItemGroup>
 
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(CopyToMods)'=='true'">


### PR DESCRIPTION
Moved configuration key `captureInLAN` up to match World Privacy Hierarchy. Introduced Harmony
patches for `CaptureThumbnailSource.GetThumbnail` and `CaptureThumbnailSource.CaptureThumbnail` to block thumbnail capture based on session access levels. (Which actually STOPS thumbnails from generating entirely - patch 1.0.3 did not fix this) 

Enhanced logic to allow exceptions for local capture or specific configurations.

Updated the project to target .NET 10.0 and use the latest C# language features. Added support for additional Resonite installation paths and included a reference to `Elements.Assets` for reflected changes to new Harmony Patches.